### PR TITLE
Add important warning about insecure instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# WARNING: THESE INSTRUCTIONS WILL SEND UNENCRYPTED LOG DATA VIA THE NETWORK!!!
+# THIS IS DANGEROUS AND NOT RECOMMENDED!
+
 ## Sending syslog from Linux systems into Graylog
 
 The two most popular syslog deamons (the programs that run in the background to accept and write or forward logs) are *rsyslog* and *syslog-ng*. One of these will most likely be running on your Linux distribution. (Please refer to your distribution documentation if you are unsure)


### PR DESCRIPTION
This practice have to be stopped. This is a bad trap for inexperienced users that are tricked into doing sysadmin stuff because "it is just one config line" - this is why this practice of not-secure-by-default-documentation is double-dangerous. See related issue #7.